### PR TITLE
Fix glob

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ JTS3_LOG="${JTS3_LOG:-JTS3ServerMod_InstanceManager.cfg}"
 
 if [ ! "$(ls -A "$JTS3_DIR/config/")" ]; then
     echo "ENTRYPOINT: JTS3 Config volume is empty, copying default files to volume"
-    cp -ar "$JTS3_DIR/default_config/*" "$JTS3_DIR/config/"
+    cp -ar "$JTS3_DIR"/default_config/* "$JTS3_DIR/config/"
 fi
 
 cd "$JTS3_DIR" || { echo "ENTRYPOINT: Failed to enter JTS3_DIR ($JTS3_DIR), exiting"; exit 1; }


### PR DESCRIPTION
Glob should be outside of the quotes, otherwise it's interpreted as filename and not expanding it.